### PR TITLE
Parser changes

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,7 @@
+chain_width = 60
+fn_call_width = 100
+fn_params_layout = "Compressed"
+max_width = 130
+newline_style = "Unix"
+single_line_if_else_max_width = 95
+struct_lit_width = 95

--- a/src/modules/alphabet.rs
+++ b/src/modules/alphabet.rs
@@ -27,16 +27,8 @@ pub fn digit() -> MonadicParser<u32> {
 
 /// Returns a [`MonadicParser`] which parses numbers.
 pub fn number() -> MonadicParser<u32> {
-    digit().repeat().filter(|v| !v.is_empty()).map(|v| {
-        let mut result = 0;
-
-        for d in v {
-            result *= 10;
-            result += d;
-        }
-
-        Some(result)
-    })
+    digit().one_or_more()
+        .map(|v| Some(v.iter().fold(0, |acc, d| acc * 10 + d)))
 }
 
 /// Returns a [`MonadicParser`] which parses escaped character satisfying `predicate`.

--- a/src/modules/alphabet.rs
+++ b/src/modules/alphabet.rs
@@ -1,5 +1,3 @@
-use crate::union;
-
 use super::monadic_parser::MonadicParser;
 
 // Parsers defining the alphabet of Regex

--- a/src/modules/alphabet.rs
+++ b/src/modules/alphabet.rs
@@ -2,7 +2,6 @@ use crate::union;
 
 use super::monadic_parser::MonadicParser;
 
-
 // Parsers defining the alphabet of Regex
 
 /// Constructs a new [`MonadicParser`] for [`prim@char`].
@@ -27,7 +26,8 @@ pub fn digit() -> MonadicParser<u32> {
 
 /// Returns a [`MonadicParser`] which parses numbers.
 pub fn number() -> MonadicParser<u32> {
-    digit().one_or_more()
+    digit()
+        .one_or_more()
         .map(|v| Some(v.iter().fold(0, |acc, d| acc * 10 + d)))
 }
 

--- a/src/modules/alphabet.rs
+++ b/src/modules/alphabet.rs
@@ -1,32 +1,32 @@
+use crate::union;
+
 use super::monadic_parser::MonadicParser;
 
-/// Constructs a new [`MonadicParser`] for [`prim@char`].
-fn init() -> MonadicParser<char> {
-    MonadicParser::new(|expr| Some((expr.chars().next()?, &expr[1..])))
-}
 
 // Parsers defining the alphabet of Regex
 
-/// Returns a [`MonadicParser`] which parses `ch`.
-pub fn character(ch: char) -> MonadicParser<char> {
-    init().filter(move |&c| c == ch)
+/// Constructs a new [`MonadicParser`] for [`prim@char`].
+pub fn any() -> MonadicParser<char> {
+    MonadicParser::new(|expr| Some((expr.chars().next()?, &expr[1..])))
 }
 
-/// Returns a [`MonadicParser`] which parses any legal [`prim@char`].
-pub fn legal_character() -> MonadicParser<char> {
-    init()
-        .exclude(move |&c| matches!(c, '^' | '$' | '|' | '*' | '?' | '+' | '.' | '\\' | '-' | '(' | ')' | '{' | '}' | '[' | ']'))
+/// Returns a [`MonadicParser`] which parses `ch`.
+pub fn character(ch: char) -> MonadicParser<char> {
+    any().filter(move |&c| c == ch)
+}
+
+/// Returns a [`MonadicParser`] which parses `s`.
+pub fn string(s: &'static str) -> MonadicParser<&'static str> {
+    MonadicParser::new(move |expr| expr.strip_prefix(s).map(|rst| (s, rst)))
 }
 
 /// Returns a [`MonadicParser`] which parses [`prim@char`] which is an ASCII digit.
-fn digit() -> MonadicParser<usize> {
-    init()
-        .filter(char::is_ascii_digit)
-        .map(|c| usize::try_from(c.to_digit(10)?).ok())
+pub fn digit() -> MonadicParser<u32> {
+    any().map(|c| c.to_digit(10))
 }
 
 /// Returns a [`MonadicParser`] which parses numbers.
-pub fn number() -> MonadicParser<usize> {
+pub fn number() -> MonadicParser<u32> {
     digit().repeat().filter(|v| !v.is_empty()).map(|v| {
         let mut result = 0;
 
@@ -40,6 +40,6 @@ pub fn number() -> MonadicParser<usize> {
 }
 
 /// Returns a [`MonadicParser`] which parses escaped character satisfying `predicate`.
-pub fn escaped_character(predicate: fn(&char) -> bool) -> MonadicParser<char> {
-    character('\\').chain(init().filter(predicate)).map(|(_, c)| Some(c))
+pub fn escaped() -> MonadicParser<char> {
+    character('\\') >> any()
 }

--- a/src/modules/alphabet.rs
+++ b/src/modules/alphabet.rs
@@ -35,3 +35,7 @@ pub fn number() -> MonadicParser<u32> {
 pub fn escaped() -> MonadicParser<char> {
     character('\\') >> any()
 }
+
+pub fn end() -> MonadicParser<()> {
+    MonadicParser::new(|expr| if expr.is_empty() { Some(((), expr)) } else { None })
+}

--- a/src/modules/grammar.rs
+++ b/src/modules/grammar.rs
@@ -35,7 +35,7 @@ pub fn regex() -> Grammar<Regex> {
 
 
 /// `Expression ::= Subexpression ('|' Subexpression)*`
-type Expression = Vec<SubExpression>;
+pub type Expression = Vec<SubExpression>;
 
 /// Returns a [`MonadicParser`] associated to the grammar rule [`Expression`].
 fn expression() -> MonadicParser<Expression> {
@@ -47,7 +47,7 @@ fn expression() -> MonadicParser<Expression> {
 
 
 /// `Subexpression ::= BasicExpression+`
-type SubExpression = Vec<BasicExpression>;
+pub type SubExpression = Vec<BasicExpression>;
 
 /// Returns a [`MonadicParser`] associated to the grammar rule [`Subexpression`].
 fn subexpression() -> MonadicParser<SubExpression> {
@@ -74,7 +74,7 @@ fn basic_expression() -> MonadicParser<BasicExpression> {
 
 /// `Quantified ::= Quantifiable Quantifier?`
 #[derive(Debug)]
-struct Quantified {
+pub struct Quantified {
 	quantified: Quantifiable,
 	quantifier: Option<Quantifier>,
 }
@@ -87,7 +87,7 @@ fn quantified() -> MonadicParser<Quantified> {
 
 /// `Quantifiable ::= Group | Match | Backreference`
 #[derive(Debug)]
-enum Quantifiable {
+pub enum Quantifiable {
     /// `Group ::= '(' Expression ')'`
     Group(Group),
     /// `Match ::= MatchItem Quantifier?`
@@ -106,15 +106,25 @@ fn quantifiable() -> MonadicParser<Quantifiable> {
 
 
 /// `Group ::= '(' Expression ')'`
-type Group = Expression;
+pub type Group = Expression;
+// /// `Group ::= '(' ":?"? Expression ')'
+// pub struct Group {
+//     non_capturing: bool,
+//     expr: Box<Expression>,
+// }
 // type Group = (bool, Expression);
 
 /// Returns a [`MonadicParser`] associated to the grammar rule [`Group`].
 fn group() -> MonadicParser<Group> {
     character('(') >> MonadicParser::lazy(expression) << character(')')
-    // (character('(') >> string(":?").optional() & expression() << character(')'))
-    //     .map(|(non_capturing, expr)| Some((non_capturing.is_some(), expr)))
-
+    // (character('(') >> string(":?").optional() & expression() << character(')')).map(
+    //     |(non_capturing, expr)| {
+    //         Some(Group {
+    //             non_capturing: non_capturing.is_some(),
+    //             expr: Box::new(expr),
+    //         })
+    //     },
+    // )
 }
 
 /// `Match ::= MatchItem`
@@ -142,14 +152,18 @@ fn r#match() -> MonadicParser<Match> {
 
 
 /// `CharacterGroup ::= '['  CharacterGroupItem+ ']'`
-type CharacterGroup = Vec<CharacterGroupItem>;
-// type CharacterGroup = (bool, Vec<CharacterGroupItem>);
+pub type CharacterGroup = Vec<CharacterGroupItem>;
+// /// `CharacterGroup ::= '[' ^? CharacterGroupItem+ ']'`
+// pub struct CharacterGroup {
+//     inverted: bool,
+//     items: Vec<CharacterGroupItem>,
+// }
 
 /// Returns a [`MonadicParser`] associated to the grammar rule [`CharacterGroup`].
 fn character_group() -> MonadicParser<CharacterGroup> {
     character('[') >> character_group_item().one_or_more() << character(']')
     // (character('[') >> character('^').optional() & character_group_item().oneOrMore() << character(']'))
-    //     .map(|(invert, items)| Some((invert.is_some(), items)))
+    //     .map(|(inverted, items)| Some(CharacterGroup{inverted:inverted.is_some(), items)))
 }
 
 
@@ -175,7 +189,7 @@ fn character_group_item() -> MonadicParser<CharacterGroupItem> {
 
 
 /// `CharacterRange ::= Char '-' Char`
-type CharacterRange = (char, char);
+pub type CharacterRange = (char, char);
 
 /// Returns a [`MonadicParser`] associated to the grammar rule [`CharacterGroupItem`].
 fn character_range() -> MonadicParser<CharacterRange> {
@@ -280,7 +294,7 @@ fn anchor() -> MonadicParser<Anchor> {
 }
 
 /// `Backreference ::= '\' 1..9`
-type Backreference = u32;
+pub type Backreference = u32;
 
 /// Returns a [`MonadicParser`] associated to the grammar rule [`Backreference`].
 fn backreference() -> MonadicParser<Backreference> {
@@ -311,7 +325,7 @@ fn quantifier() -> MonadicParser<Quantifier> {
 }
 
 /// `RangeQuantifier ::= '{' RangeQuantifierLowerBound ( ',' RangeQuantifierUpperBound? )? '}'`
-type RangeQuantifier = (u32, Option<u32>);
+pub type RangeQuantifier = (u32, Option<u32>);
 
 /// Returns a [`MonadicParser`] associated to the grammar rule [`RangeQuantifier`].
 fn range_quantifier() -> MonadicParser<RangeQuantifier> {

--- a/src/modules/grammar.rs
+++ b/src/modules/grammar.rs
@@ -27,18 +27,14 @@ pub fn regex() -> Grammar<Regex> {
     expression() << end()
 }
 
-
 /// `Expression ::= Subexpression ('|' Subexpression)*`
 pub type Expression = Vec<SubExpression>;
 
 /// Returns a [`MonadicParser`] associated to the grammar rule [`Expression`].
 fn expression() -> MonadicParser<Expression> {
     (subexpression() & (character('|') >> subexpression()).repeat())
-        .map(|(first, mut rest)|
-            Some(iter::once(first).chain(rest.drain(..)).collect())
-        )
+        .map(|(first, mut rest)| Some(iter::once(first).chain(rest.drain(..)).collect()))
 }
-
 
 /// `Subexpression ::= BasicExpression+`
 pub type SubExpression = Vec<BasicExpression>;
@@ -47,7 +43,6 @@ pub type SubExpression = Vec<BasicExpression>;
 fn subexpression() -> MonadicParser<SubExpression> {
     basic_expression().one_or_more()
 }
-
 
 /// `BasicExpression ::= Anchor | Quantified`
 #[derive(Debug)]
@@ -65,19 +60,16 @@ fn basic_expression() -> MonadicParser<BasicExpression> {
     )
 }
 
-
 /// `Quantified ::= Quantifiable Quantifier?`
 #[derive(Debug)]
 pub struct Quantified {
-	quantified: Quantifiable,
-	quantifier: Option<Quantifier>,
+    quantified: Quantifiable,
+    quantifier: Option<Quantifier>,
 }
 
 fn quantified() -> MonadicParser<Quantified> {
-    (quantifiable() & quantifier().optional())
-        .map(|(qd, qr)| Some(Quantified{ quantified:qd, quantifier:qr }))
+    (quantifiable() & quantifier().optional()).map(|(qd, qr)| Some(Quantified { quantified: qd, quantifier: qr }))
 }
-
 
 /// `Quantifiable ::= Group | Match | Backreference`
 #[derive(Debug)]
@@ -97,7 +89,6 @@ fn quantifiable() -> MonadicParser<Quantifiable> {
         backreference().map(|br| Some(Quantifiable::Backreference(br)))
     )
 }
-
 
 /// `Group ::= '(' Expression ')'`
 pub type Group = Expression;
@@ -144,7 +135,6 @@ fn r#match() -> MonadicParser<Match> {
     ]
 }
 
-
 /// `CharacterGroup ::= '['  CharacterGroupItem+ ']'`
 pub type CharacterGroup = Vec<CharacterGroupItem>;
 // /// `CharacterGroup ::= '[' ^? CharacterGroupItem+ ']'`
@@ -160,7 +150,6 @@ fn character_group() -> MonadicParser<CharacterGroup> {
     //     .map(|(inverted, items)| Some(CharacterGroup{inverted:inverted, items}))
 }
 
-
 /// `CharacterGroupItem ::= CharacterClass | CharacterRange | Char`
 #[derive(Debug)]
 pub enum CharacterGroupItem {
@@ -169,7 +158,7 @@ pub enum CharacterGroupItem {
     /// `CharacterRange ::= Char '-' Char`
     CharacterRange(CharacterRange),
     /// `Char ::= Char`
-    Char(char)
+    Char(char),
 }
 
 /// Returns a [`MonadicParser`] associated to the grammar rule [`CharacterGroupItem`].
@@ -180,7 +169,6 @@ fn character_group_item() -> MonadicParser<CharacterGroupItem> {
         character_group_char().map(|c| Some(CharacterGroupItem::Char(c)))
     ]
 }
-
 
 /// `CharacterRange ::= Char '-' Char`
 pub type CharacterRange = (char, char);
@@ -202,7 +190,6 @@ fn character_group_char() -> MonadicParser<char> {
 fn char_group_special(c: &char) -> bool {
     matches!(c, '^' | '\\' | '-' | ']')
 }
-
 
 /// `CharacterClass ::= '\w' | '\W' | '\d' | '\D | '\s' | '\S'`
 #[derive(Debug)]
@@ -254,7 +241,7 @@ fn control_char() -> MonadicParser<char> {
         'v' => Some('\x0b'),
         'f' => Some('\x0c'),
         '0' => Some('\0'),
-        _ => None
+        _ => None,
     })
 }
 

--- a/src/modules/grammar.rs
+++ b/src/modules/grammar.rs
@@ -279,12 +279,12 @@ fn anchor() -> MonadicParser<Anchor> {
     ]
 }
 
-/// `Backreference ::= '\' Integer`
+/// `Backreference ::= '\' 1..9`
 type Backreference = u32;
 
 /// Returns a [`MonadicParser`] associated to the grammar rule [`Backreference`].
 fn backreference() -> MonadicParser<Backreference> {
-    escaped().map(|c| c.to_digit(10))
+    escaped().map(|c| c.to_digit(10)).exclude(|&n| n == 0)
 }
 
 /// `Quantifier ::= '*' | '+' | '?' | RangeQuantifier`

--- a/src/modules/grammar.rs
+++ b/src/modules/grammar.rs
@@ -2,7 +2,7 @@ use std::iter;
 
 use crate::union;
 
-use super::alphabet::*;
+use super::alphabet::{any, character, end, escaped, number};
 use super::monadic_parser::MonadicParser;
 
 /// A [`MonadicParser`] defining the rules of a formal grammar

--- a/src/modules/monadic_parser.rs
+++ b/src/modules/monadic_parser.rs
@@ -57,13 +57,15 @@ impl<T: 'static> MonadicParser<T> {
     }
 
     pub fn optional(self) -> MonadicParser<Option<T>> {
-        MonadicParser::new(move |expr| {
-            if let Some((t, rst)) = self.parse(expr) {
-                Some((Some(t), rst))
-            } else {
-                Some((None, expr))
-            }
-        })
+        MonadicParser::new(
+            move |expr| {
+                if let Some((t, rst)) = self.parse(expr) {
+                    Some((Some(t), rst))
+                } else {
+                    Some((None, expr))
+                }
+            },
+        )
     }
 
     pub fn exists(self) -> MonadicParser<bool> {

--- a/src/modules/monadic_parser.rs
+++ b/src/modules/monadic_parser.rs
@@ -66,6 +66,10 @@ impl<T: 'static> MonadicParser<T> {
         })
     }
 
+    pub fn exists(self) -> MonadicParser<bool> {
+        self.optional().map(|x| Some(x.is_some()))
+    }
+
     pub fn lazy<F: Fn() -> MonadicParser<T> + 'static>(closure: F) -> Self {
         MonadicParser::new(move |expr| closure().parse(expr))
     }

--- a/src/modules/monadic_parser.rs
+++ b/src/modules/monadic_parser.rs
@@ -1,3 +1,5 @@
+use std::ops;
+
 type ParserFunction<T> = dyn Fn(& str) -> Option<(T, &str)>;
 
 pub struct MonadicParser<T> {
@@ -6,10 +8,6 @@ pub struct MonadicParser<T> {
 
 impl<T: 'static> MonadicParser<T> {
     pub fn new<F: Fn(& str) -> Option<(T, &str)> + 'static>(f: F) -> Self {
-        MonadicParser::unit(f)
-    }
-
-    fn unit<F: Fn(& str) -> Option<(T, &str)> + 'static>(f: F) -> Self {
         MonadicParser { fcn: Box::new(f) }
     }
 
@@ -18,7 +16,7 @@ impl<T: 'static> MonadicParser<T> {
     }
 
     pub fn chain<U: 'static>(self, other: MonadicParser<U>) -> MonadicParser<(T, U)> {
-        MonadicParser::unit(move |expr| {
+        MonadicParser::new(move |expr| {
             let (t, rst_t) = self.parse(expr)?;
             let (u, rst_u) = other.parse(rst_t)?;
 
@@ -27,7 +25,7 @@ impl<T: 'static> MonadicParser<T> {
     }
 
     pub fn map<U: 'static, F: Fn(T) -> Option<U> + 'static>(self, transform: F) -> MonadicParser<U> {
-        MonadicParser::unit(move |expr| {
+        MonadicParser::new(move |expr| {
             let (t, rst) = self.parse(expr)?;
             Some((transform(t)?, rst))
         })
@@ -42,22 +40,24 @@ impl<T: 'static> MonadicParser<T> {
     }
 
     pub fn repeat(self) -> MonadicParser<Vec<T>> {
-        MonadicParser::unit(move |expr| {
+        MonadicParser::new(move |expr| {
             let mut current_expr = expr;
             let mut res = vec![];
             while let Some((t, rst)) = self.parse(current_expr) {
                 res.push(t);
                 current_expr = rst;
-                // *expr = expr.split_off(1);
-                // println!("after: {expr}");
             }
 
             Some((res, current_expr))
         })
     }
 
+    pub fn one_or_more(self) -> MonadicParser<Vec<T>> {
+        self.repeat().exclude(Vec::is_empty)
+    }
+
     pub fn optional(self) -> MonadicParser<Option<T>> {
-        MonadicParser::unit(move |expr| {
+        MonadicParser::new(move |expr| {
             if let Some((t, rst)) = self.parse(expr) {
                 Some((Some(t), rst))
             } else {
@@ -68,6 +68,30 @@ impl<T: 'static> MonadicParser<T> {
 
     pub fn lazy<F: Fn() -> MonadicParser<T> + 'static>(closure: F) -> Self {
         MonadicParser::new(move |expr| closure().parse(expr))
+    }
+}
+
+impl<T: 'static, U: 'static> ops::BitAnd<MonadicParser<U>> for MonadicParser<T> {
+    type Output = MonadicParser<(T, U)>;
+
+    fn bitand(self, rhs: MonadicParser<U>) -> Self::Output {
+        self.chain(rhs)
+    }
+}
+
+impl<T: 'static, U: 'static> ops::Shl<MonadicParser<U>> for MonadicParser<T> {
+    type Output = MonadicParser<T>;
+
+    fn shl(self, rhs: MonadicParser<U>) -> Self::Output {
+        self.chain(rhs).map(|(t, _)| Some(t))
+    }
+}
+
+impl<T: 'static, U: 'static> ops::Shr<MonadicParser<U>> for MonadicParser<T> {
+    type Output = MonadicParser<U>;
+
+    fn shr(self, rhs: MonadicParser<U>) -> Self::Output {
+        self.chain(rhs).map(|(_, u)| Some(u))
     }
 }
 


### PR DESCRIPTION
I may have gone too far. Feel free to disagree with anything.

I overloaded operators `>>`, `<<`, and `&` for chaining. It's not perfect since they don't have the same precedence, but I couldn't come up with something better than still looked readable.

I also changed the grammar
* allow escaping control characters
* change the set of characters that need to be escaped in a character group
* moved the quantified parts of the expression into their own component of the grammar (this makes more sense to me than attaching quantifiers to groups, characters, etc. individually).
* generally tried to make it more readable