### PR TITLE
Compilation of grammar into NFA via `AbstractSyntaxTree`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,8 @@ use std::io::{self, Write};
 
 fn main() {
     let expr = r"^@\w+\.\b\{\w{2,3}(.\w{2,})?|c?[a-z\w\s]+\1";
-    println!("{:#?}", language::regex().parse(expr).unwrap());
+    let regex = language::regex();
+    println!("{:#?}", regex.syntax(expr).unwrap());
 
     // something to get rid of unused code warnings
     loop {
@@ -14,6 +15,7 @@ fn main() {
         if regexp_input.is_empty() {
             break;
         }
+        println!("{:#?}", regex.syntax(&regexp_input).unwrap());
 
         match RegExp::new(&regexp_input) {
             Ok(regexp) => {

--- a/src/modules/abstract_syntax_tree.rs
+++ b/src/modules/abstract_syntax_tree.rs
@@ -1,6 +1,8 @@
 use super::automata::Automata;
 use super::error::Error;
-use super::grammar::{Anchor, BasicExpression, CharacterClass, Expression, Match, Quantifiable, Quantified, Quantifier, SubExpression};
+use super::grammar::{
+    Anchor, BasicExpression, CharacterClass, Expression, Match, Quantifiable, Quantified, Quantifier, SubExpression,
+};
 use super::state::Anchor as StateAnchor;
 
 pub trait AbstractSyntaxTree {

--- a/src/modules/abstract_syntax_tree.rs
+++ b/src/modules/abstract_syntax_tree.rs
@@ -1,0 +1,111 @@
+use super::automata::Automata;
+use super::error::Error;
+use super::grammar::{Anchor, BasicExpression, CharacterClass, Expression, Match, Quantifiable, Quantified, Quantifier, SubExpression};
+use super::state::Anchor as StateAnchor;
+
+pub trait AbstractSyntaxTree {
+    fn compile(&self) -> Result<Automata, Error>;
+}
+
+impl AbstractSyntaxTree for Expression {
+    fn compile(&self) -> Result<Automata, Error> {
+        let mut it = self.iter();
+        let initial_sub_expr = it
+            .next()
+            .ok_or_else(|| Error::from("Internal error: No SubExpression in Regex"))?;
+
+        it.fold(initial_sub_expr.compile(), |acc, basic_expr| Ok(acc?.or(basic_expr.compile()?)))
+    }
+}
+
+impl AbstractSyntaxTree for SubExpression {
+    fn compile(&self) -> Result<Automata, Error> {
+        let mut it = self.iter();
+        let initial_basic_expr = it
+            .next()
+            .ok_or_else(|| Error::from("Internal error: No BasicExpression in SubExpression"))?;
+
+        it.fold(initial_basic_expr.compile(), |acc, basic_expr| Ok(acc?.concat(basic_expr.compile()?)))
+    }
+}
+
+impl AbstractSyntaxTree for BasicExpression {
+    fn compile(&self) -> Result<Automata, Error> {
+        match self {
+            BasicExpression::Anchor(anchor) => anchor.compile(),
+            BasicExpression::Quantified(quantified) => quantified.compile(),
+        }
+    }
+}
+
+impl AbstractSyntaxTree for Anchor {
+    fn compile(&self) -> Result<Automata, Error> {
+        match self {
+            Anchor::Start => Ok(Automata::from_anchor(StateAnchor::Start)),
+            Anchor::End => Ok(Automata::from_anchor(StateAnchor::End)),
+            Anchor::WordBoundary => Ok(Automata::from_anchor(StateAnchor::WordBoundary)),
+            Anchor::NotWordBoundary => todo!(),
+        }
+    }
+}
+
+impl AbstractSyntaxTree for Quantified {
+    fn compile(&self) -> Result<Automata, Error> {
+        let (quantifiable, maybe_quantifier) = self;
+        let automata = quantifiable.compile();
+
+        if let Some(quantifier) = maybe_quantifier {
+            match quantifier {
+                Quantifier::ZeroOrMore => Ok(automata?.closure()),
+                Quantifier::OneOrMore => Ok(automata?.plus()),
+                Quantifier::ZeroOrOne => Ok(automata?.optional()),
+                Quantifier::Range((lower, maybe_upper)) => (0..(*lower).saturating_sub(1))
+                    .fold(automata, |acc, _| Ok(acc?.concat(quantifiable.compile()?)))
+                    .and_then(|auto_lower| {
+                        if let Some(upper) = maybe_upper {
+                            (0..(*upper).saturating_sub(*lower))
+                                .fold(Ok(auto_lower), |acc, _| Ok(acc?.concat(quantifiable.compile()?.optional())))
+                        } else {
+                            Ok(auto_lower.plus())
+                        }
+                    }),
+            }
+        } else {
+            automata
+        }
+    }
+}
+
+impl AbstractSyntaxTree for Quantifiable {
+    fn compile(&self) -> Result<Automata, Error> {
+        match self {
+            Quantifiable::Group(g) => g.compile(),
+            Quantifiable::Match(m) => m.compile(),
+            Quantifiable::Backreference(_) => Err(Error::from("Internal Error: Backreference not implemented!")),
+        }
+    }
+}
+
+impl AbstractSyntaxTree for Match {
+    fn compile(&self) -> Result<Automata, Error> {
+        match self {
+            Match::Any => Ok(Automata::from_lambda(|_| true)),
+            Match::CharacterClass(cc) => cc.compile(),
+            Match::CharacterGroup(_) => todo!(),
+            Match::Char(c) => Ok(Automata::from_token(*c)),
+        }
+    }
+}
+
+impl AbstractSyntaxTree for CharacterClass {
+    fn compile(&self) -> Result<Automata, Error> {
+        Ok(match self {
+            CharacterClass::Alphanumeric => Automata::from_lambda(|x| x.is_ascii_alphanumeric()),
+            CharacterClass::NotAlphanumeric => Automata::from_lambda(|x| !x.is_ascii_alphanumeric()),
+            CharacterClass::Digit => Automata::from_lambda(|x| x.is_ascii_digit()),
+            CharacterClass::NotDigit => Automata::from_lambda(|x| !x.is_ascii_digit()),
+            CharacterClass::Whitespace => Automata::from_lambda(|x| x.is_ascii_whitespace()),
+            CharacterClass::NotWhitespace => Automata::from_lambda(|x| !x.is_ascii_whitespace()),
+        })
+    }
+}

--- a/src/modules/abstract_syntax_tree.rs
+++ b/src/modules/abstract_syntax_tree.rs
@@ -5,7 +5,9 @@ use super::grammar::{
 };
 use super::state::Anchor as StateAnchor;
 
+/// A trait that allows types to be compiled into an [`Automata`].
 pub trait AbstractSyntaxTree {
+    /// Compiles type into an [`Automata`]
     fn compile(&self) -> Result<Automata, Error>;
 }
 

--- a/src/modules/abstract_syntax_tree.rs
+++ b/src/modules/abstract_syntax_tree.rs
@@ -94,7 +94,7 @@ impl AbstractSyntaxTree for Match {
             Match::Any => Ok(Automata::from_lambda(|_| true)),
             Match::CharacterClass(cc) => cc.compile(),
             Match::CharacterGroup(cg) => cg.compile(),
-            Match::Char(c) => Ok(Automata::from_token(*c)),
+            Match::Char(c) => c.compile(),
         }
     }
 }
@@ -123,7 +123,13 @@ impl AbstractSyntaxTree for CharacterGroupItem {
         match self {
             CharacterGroupItem::CharacterClass(cc) => cc.compile(),
             CharacterGroupItem::CharacterRange(_) => todo!(),
-            CharacterGroupItem::Char(c) => Ok(Automata::from_token(*c)),
+            CharacterGroupItem::Char(c) => c.compile(),
         }
+    }
+}
+
+impl AbstractSyntaxTree for char {
+    fn compile(&self) -> Result<Automata, Error> {
+        Ok(Automata::from_token(*self))
     }
 }

--- a/src/modules/abstract_syntax_tree.rs
+++ b/src/modules/abstract_syntax_tree.rs
@@ -3,7 +3,6 @@ use super::error::Error;
 use super::grammar::{
     Anchor, BasicExpression, CharacterClass, Expression, Match, Quantifiable, Quantified, Quantifier, SubExpression,
 };
-use super::state::Anchor as StateAnchor;
 
 /// A trait that allows types to be compiled into an [`Automata`].
 pub trait AbstractSyntaxTree {
@@ -44,12 +43,7 @@ impl AbstractSyntaxTree for BasicExpression {
 
 impl AbstractSyntaxTree for Anchor {
     fn compile(&self) -> Result<Automata, Error> {
-        match self {
-            Anchor::Start => Ok(Automata::from_anchor(StateAnchor::Start)),
-            Anchor::End => Ok(Automata::from_anchor(StateAnchor::End)),
-            Anchor::WordBoundary => Ok(Automata::from_anchor(StateAnchor::WordBoundary)),
-            Anchor::NotWordBoundary => todo!(),
-        }
+        Ok(Automata::from_anchor(*self))
     }
 }
 

--- a/src/modules/ast.rs
+++ b/src/modules/ast.rs
@@ -21,7 +21,7 @@ fn fold<T: AbstractSyntaxTree>(
         .next()
         .ok_or_else(|| Error::from(format!("Internal error: No {sub_name} in {name}").as_str()))?;
 
-    it.fold(initial.compile(), |acc, block| Ok(f(acc?, block.compile()?)))
+    it.fold(initial.compile(), |acc, subsequent| Ok(f(acc?, subsequent.compile()?)))
 }
 
 impl AbstractSyntaxTree for Expression {

--- a/src/modules/ast.rs
+++ b/src/modules/ast.rs
@@ -3,8 +3,8 @@ use std::slice::Iter;
 use super::automata::Automata;
 use super::error::Error;
 use super::grammar::{
-    Anchor, BasicExpression, CharacterClass, CharacterGroup, CharacterGroupItem, Expression, Match, Quantifiable, Quantified,
-    Quantifier, SubExpression,
+    Anchor, BasicExpression, CharacterClass, CharacterGroup, CharacterGroupItem, Expression, Group, Match, Quantifiable,
+    Quantified, Quantifier, SubExpression,
 };
 
 /// A trait that allows types to be compiled into an [`Automata`].
@@ -23,6 +23,8 @@ fn fold<T: AbstractSyntaxTree>(
 
     it.fold(initial.compile(), |acc, subsequent| Ok(f(acc?, subsequent.compile()?)))
 }
+
+// Implementation of AbstractSyntaxTree for elements of Regex
 
 impl AbstractSyntaxTree for Expression {
     fn compile(&self) -> Result<Automata, Error> {
@@ -85,6 +87,14 @@ impl AbstractSyntaxTree for Quantifiable {
             Quantifiable::Match(m) => m.compile(),
             Quantifiable::Backreference(_) => Err(Error::from("Internal Error: Backreference not implemented!")),
         }
+    }
+}
+
+impl AbstractSyntaxTree for Group {
+    fn compile(&self) -> Result<Automata, Error> {
+        println!("Non capturing mode: {}", self.0);
+
+        self.1.compile()
     }
 }
 

--- a/src/modules/automata.rs
+++ b/src/modules/automata.rs
@@ -3,7 +3,8 @@ use std::fmt::{Debug, Formatter, Result};
 use std::rc::Rc;
 use std::str::Chars;
 
-use super::state::{Anchor, AnchorState, LambdaState, State, TokenState, TrivialState};
+use super::grammar::Anchor;
+use super::state::{AnchorState, LambdaState, State, TokenState, TrivialState};
 
 type StatePtr = Rc<RefCell<dyn State>>;
 

--- a/src/modules/grammar.rs
+++ b/src/modules/grammar.rs
@@ -6,13 +6,13 @@ use super::alphabet::{any, character, end, escaped, number};
 use super::monadic_parser::MonadicParser;
 
 /// A [`MonadicParser`] defining the rules of a formal grammar.
-pub type Grammar<S> = MonadicParser<S>;
+pub type Grammar<T> = MonadicParser<T>;
 
-impl<S: 'static> Grammar<S> {
+impl<T: 'static> Grammar<T> {
     /// Compiles specification `spec` of a formal grammar to the associated [`Grammar`].
     ///
-    /// A specification of a formal grammar is a function `fn() -> Grammar<S>` which returns (the [`MonadicParser`] defining) the rules of the formal grammar.
-    pub fn compile(spec: fn() -> Grammar<S>) -> Self {
+    /// A specification of a formal grammar is a function `fn() -> Grammar<T>` which returns (the [`MonadicParser`] defining) the rules of the formal grammar.
+    pub fn compile(spec: fn() -> Grammar<T>) -> Self {
         spec()
     }
 }

--- a/src/modules/grammar.rs
+++ b/src/modules/grammar.rs
@@ -60,7 +60,7 @@ fn basic_expression() -> MonadicParser<BasicExpression> {
 }
 
 /// `Anchor ::= '^' | '$' | '\b' | '\B'`
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Anchor {
     Start,
     End,

--- a/src/modules/grammar.rs
+++ b/src/modules/grammar.rs
@@ -2,7 +2,7 @@ use std::iter;
 
 use crate::union;
 
-use super::alphabet::{any, character, end, escaped, number};
+use super::alphabet::{any, character, end, escaped, number, string};
 use super::monadic_parser::MonadicParser;
 
 /// A [`MonadicParser`] defining the rules of a formal grammar.
@@ -106,18 +106,16 @@ fn quantifiable() -> MonadicParser<Quantifiable> {
     )
 }
 
-/// `Group ::= '(' Expression ')'`
-pub type Group = Expression;
-// /// `Group ::= '(' ":?"? Expression ')'`
+/// `Group ::= '(' ":?"? Expression ')'`
+pub type Group = (bool, Expression);
 // pub struct Group {
 //     non_capturing: bool,
 //     expr: Box<Expression>,
 // }
-// type Group = (bool, Expression);
 
 /// Returns a [`MonadicParser`] associated to the grammar rule [`Group`].
 fn group() -> MonadicParser<Group> {
-    character('(') >> MonadicParser::lazy(expression) << character(')')
+    character('(') >> string(":?").exists() & MonadicParser::lazy(expression) << character(')')
     // (character('(') >> string(":?").exists() & expression() << character(')')).map(
     //     |(non_capturing, expr)| {
     //         Some(Group {

--- a/src/modules/language.rs
+++ b/src/modules/language.rs
@@ -7,13 +7,13 @@ use super::{
 };
 
 /// A modal for formal language
-pub struct Language<S> {
-    grammar: Grammar<S>,
+pub struct Language<T> {
+    grammar: Grammar<T>,
 }
 
-impl<S: AbstractSyntaxTree + 'static> Language<S> {
+impl<T: AbstractSyntaxTree + 'static> Language<T> {
     /// Constructs a [`Language`] associated to the formal grammar compiled using specification `spec`.
-    pub fn new(spec: fn() -> Grammar<S>) -> Self {
+    pub fn new(spec: fn() -> Grammar<T>) -> Self {
         Language { grammar: Grammar::compile(spec) }
     }
 
@@ -25,8 +25,8 @@ impl<S: AbstractSyntaxTree + 'static> Language<S> {
     }
 
     /// Returns the syntax representation of `expr` using [`Language`]'s grammar.
-    pub fn syntax(&self, expr: &str) -> Option<S> {
-        self.grammar.parse(expr).map(|(s, _)| s)
+    pub fn syntax(&self, expr: &str) -> Option<T> {
+        self.grammar.parse(expr).map(|(t, _)| t)
     }
 }
 

--- a/src/modules/language.rs
+++ b/src/modules/language.rs
@@ -1,3 +1,6 @@
+use super::abstract_syntax_tree::AbstractSyntaxTree;
+use super::automata::Automata;
+use super::error::Error;
 use super::{
     grammar,
     grammar::{Grammar, Regex},
@@ -8,14 +11,21 @@ pub struct Language<S> {
     grammar: Grammar<S>,
 }
 
-impl<S: 'static> Language<S> {
+impl<S: AbstractSyntaxTree + 'static> Language<S> {
     /// Constructs a [`Language`] associated to the formal grammar compiled using specification `spec`.
     pub fn new(spec: fn() -> Grammar<S>) -> Self {
         Language { grammar: Grammar::compile(spec) }
     }
 
     /// Parses `expr` using [`Language`]'s grammar.
-    pub fn parse(&self, expr: &str) -> Option<S> {
+    pub fn parse(&self, expr: &str) -> Result<Automata, Error> {
+        self.syntax(expr)
+            .ok_or_else(|| Error::from("Internal error: expr parsed into an empty Expression"))?
+            .compile()
+    }
+
+    /// Returns the syntax representation of `expr` using [`Language`]'s grammar.
+    pub fn syntax(&self, expr: &str) -> Option<S> {
         self.grammar.parse(expr).map(|(s, _)| s)
     }
 }

--- a/src/modules/language.rs
+++ b/src/modules/language.rs
@@ -1,4 +1,4 @@
-use super::abstract_syntax_tree::AbstractSyntaxTree;
+use super::ast::AbstractSyntaxTree;
 use super::automata::Automata;
 use super::error::Error;
 use super::{

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,9 +1,9 @@
+mod abstract_syntax_tree;
 mod alphabet;
 mod automata;
 mod error;
 mod grammar;
 pub mod language;
 mod monadic_parser;
-mod parser;
 pub mod regexp;
 mod state;

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,5 +1,5 @@
-mod abstract_syntax_tree;
 mod alphabet;
+mod ast;
 mod automata;
 mod error;
 mod grammar;

--- a/src/modules/regexp.rs
+++ b/src/modules/regexp.rs
@@ -1,6 +1,6 @@
 use super::automata::Automata;
 use super::error::Error;
-use super::parser;
+use super::language;
 
 pub struct RegExp {
     automata: Automata,
@@ -8,7 +8,7 @@ pub struct RegExp {
 
 impl RegExp {
     pub fn new(expr: &str) -> Result<Self, Error> {
-        Ok(RegExp { automata: parser::parse(expr)? })
+        Ok(RegExp { automata: language::regex().parse(expr)? })
     }
 
     pub fn full_match(&self, expr: &str) -> bool {

--- a/src/modules/state/anchor.rs
+++ b/src/modules/state/anchor.rs
@@ -3,14 +3,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::{ptr, slice};
 
-use super::State;
-
-#[derive(Debug, PartialEq)]
-pub enum Anchor {
-    Start,
-    End,
-    WordBoundary,
-}
+use super::{Anchor, State};
 
 pub struct AnchorState {
     anchor: Anchor,

--- a/src/modules/state/mod.rs
+++ b/src/modules/state/mod.rs
@@ -3,7 +3,6 @@ mod lambda;
 mod token;
 mod trivial;
 
-pub use self::anchor::Anchor;
 pub use self::anchor::AnchorState;
 pub use self::lambda::LambdaState;
 pub use self::token::TokenState;
@@ -13,6 +12,8 @@ use std::any::Any;
 use std::cell::RefCell;
 use std::fmt::{Debug, Formatter, Result};
 use std::rc::Rc;
+
+use super::grammar::Anchor;
 
 pub trait State {
     fn epsilon(&self, anchors: &[Anchor]) -> &[Rc<RefCell<dyn State>>];


### PR DESCRIPTION
Logic to compile output of `MonadicParser::parse` into `Automata`.

This should bring us back to where we were, but with the new parser paradigm.